### PR TITLE
Allow running in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+bin/OS/linux/FasterCode.*
+Dockerfile
+.dockerignore
+UserData

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+UserData/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Build & run with:
+# docker build . -t lucaschess && docker run -it -e "DISPLAY=$DISPLAY" -v "$HOME/.Xauthority:/lucaschess/.Xauthority:ro" -v "$PWD/UserData:/lucaschess/UserData" --network host --rm lucaschess
+
+FROM python:3.9-bullseye
+WORKDIR /lucaschess/
+ENV HOME=/lucaschess/
+
+RUN apt-get update && \
+	apt-get install -y portaudio19-dev libqt5gui5 && \
+	rm -rf /var/lib/apt/lists/*
+
+ADD requirements.txt ./
+RUN pip install -r requirements.txt
+
+ADD . .
+RUN cd bin/_fastercode && chmod a+x ./linux64.sh && ./linux64.sh
+RUN cd bin/_genicons && python ./gentema.py
+RUN chmod a+x bin/LucasR.py
+WORKDIR /lucaschess/bin/
+
+# To debug problems with Qt, enable the following line:
+# ENV QT_DEBUG_PLUGINS=1
+
+CMD ./LucasR.py

--- a/bin/LucasR.py
+++ b/bin/LucasR.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # ==============================================================================
 # Author : Lucas Monge, lukasmonk@gmail.com
 # Web : http://lucaschess.pythonanywhere.com/


### PR DESCRIPTION
I was unable to install lucaschessR dependencies on my host system, as a precise Python version is rquired.

Add a Dockerfile that can be used to start LucasChessR reproducibly, no matter the Python version and other details on the host, as long as it's running X11.

Also make `bin/LucasR.py` a proper executable.
